### PR TITLE
Add user-agent metrics to API handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,11 @@ require github.com/google/uuid v1.6.0
 
 require github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 
-require github.com/mileusna/useragent v1.3.4 // indirect
+require github.com/mileusna/useragent v1.3.4
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.9.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,15 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/mileusna/useragent v1.3.4 h1:MiuRRuvGjEie1+yZHO88UBYg8YBC/ddF6T7F56i3PCk=
 github.com/mileusna/useragent v1.3.4/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/api/tracker.go
+++ b/pkg/api/tracker.go
@@ -1,0 +1,59 @@
+package api
+
+import "sync"
+
+// UserAgentTracker is a simple async hashmap that
+// tracks the reported User-Agent strings
+type UserAgentTracker struct {
+	lock           sync.RWMutex
+	userAgentsSeen UserAgentMaps
+}
+
+// UserAgentMaps track seen user agent strings across different API endpoints
+// the hashmap takes the form of User-Agent:seen_count
+type UserAgentMaps struct {
+	root    map[string]int
+	license map[string]int
+	bulk    map[string]int
+}
+
+// NewUserAgentTracker returns a new tracker
+func NewUserAgentTracker() *UserAgentTracker {
+	return &UserAgentTracker{
+		lock: sync.RWMutex{},
+		userAgentsSeen: UserAgentMaps{
+			root:    make(map[string]int),
+			license: make(map[string]int),
+			bulk:    make(map[string]int),
+		},
+	}
+}
+
+// RootSeen increments a counter for the / endpoint
+func (uat *UserAgentTracker) RootSeen(agent string) {
+	uat.lock.Lock()
+	defer uat.lock.Unlock()
+	uat.userAgentsSeen.root[agent]++
+}
+
+// BulkSeen increments a counter for the /_bulk endpoint
+func (uat *UserAgentTracker) BulkSeen(agent string) {
+	uat.lock.Lock()
+	defer uat.lock.Unlock()
+	uat.userAgentsSeen.bulk[agent]++
+}
+
+// BulkSeen increments a counter for the /license endpoint
+func (uat *UserAgentTracker) LicenseSeen(agent string) {
+	uat.lock.Lock()
+	defer uat.lock.Unlock()
+	uat.userAgentsSeen.license[agent]++
+}
+
+// Get returns all metrics for the User Agent
+func (uat *UserAgentTracker) Get() UserAgentMaps {
+	uat.lock.RLock()
+	defer uat.lock.RUnlock()
+
+	return uat.userAgentsSeen
+}

--- a/pkg/api/tracker_test.go
+++ b/pkg/api/tracker_test.go
@@ -1,0 +1,67 @@
+package api
+
+import (
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rcrowley/go-metrics"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserAgentTracker(t *testing.T) {
+	isStarted := sync.WaitGroup{}
+	isStarted.Add(1)
+	handler := NewAPIHandler(uuid.New(), "", metrics.DefaultRegistry, time.Now().Add(24*time.Hour), 0, 0, 0, 0, 0)
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/", handler)
+		isStarted.Done()
+		if err := http.ListenAndServe(":9200", mux); err != nil {
+			if err != http.ErrServerClosed {
+				require.NoError(t, err)
+				isStarted.Done()
+			}
+		}
+	}()
+
+	isStarted.Wait()
+
+	getCount := 5
+
+	writers := sync.WaitGroup{}
+	writers.Add(getCount * 2)
+	go func() {
+		for i := 0; i < getCount; i++ {
+			client := &http.Client{Timeout: time.Second * 10}
+			req, err := http.NewRequest("GET", "http://localhost:9200/", nil)
+			require.NoError(t, err)
+
+			req.Header.Set("User-Agent", "root-get")
+			_, err = client.Do(req)
+			require.NoError(t, err)
+			writers.Done()
+		}
+	}()
+
+	go func() {
+		for i := 0; i < getCount; i++ {
+			client := &http.Client{Timeout: time.Second * 10}
+			req, err := http.NewRequest("GET", "http://localhost:9200/_license", nil)
+			require.NoError(t, err)
+
+			req.Header.Set("User-Agent", "license-get")
+			_, err = client.Do(req)
+			require.NoError(t, err)
+			writers.Done()
+		}
+	}()
+
+	writers.Wait()
+
+	data := handler.UserAgents.Get()
+	expected := UserAgentMaps{root: map[string]int{"root-get": 5}, license: map[string]int{"license-get": 5}, bulk: map[string]int{}}
+	require.Equal(t, expected, data)
+}


### PR DESCRIPTION
This adds a `UserAgentTracker` to the API handler that tracks the user-agent values seen across the API, and exposes the values in a struct value. This also adds tests, and fixes a few things my linter was complaining about, notably the `go.mod` file and the HTTP callbacks.

This is needed for testing the more sophisticated User-Agent strings we're planning for beats.