### PR TITLE
Include genuine header

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -95,8 +95,7 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	incrementCounter("user_agent."+ua.String+".total", h.metricsRegistry)
 	incrementCounter("user_agent."+ua.String+"."+r.URL.Path, h.metricsRegistry)
 
-	// NOTE: required for official clients to recognize this as a valid endpoint.
-	// See genuineCheckHeader at https://github.com/elastic/elasticsearch-serverless-go/blob/0aad511503d4b827e0200482633e1c3974ec8593/elasticsearch.go#L303
+	// required for official clients to recognize this as a valid endpoint.
 	w.Header().Set("X-Elastic-Product", "Elasticsearch")
 
 	switch {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -92,8 +92,13 @@ func NewAPIHandler(uuid uuid.UUID, clusterUUID string, metricsRegistry metrics.R
 func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	time.Sleep(h.Delay)
 	ua := useragent.Parse(r.Header.Get("User-Agent"))
-	incrementCounter("user_agent."+ ua.String + ".total", h.metricsRegistry)
-	incrementCounter("user_agent."+ ua.String + "." + r.URL.Path, h.metricsRegistry)
+	incrementCounter("user_agent."+ua.String+".total", h.metricsRegistry)
+	incrementCounter("user_agent."+ua.String+"."+r.URL.Path, h.metricsRegistry)
+
+	// NOTE: required for official clients to recognize this as a valid endpoint.
+	// See genuineCheckHeader at https://github.com/elastic/elasticsearch-serverless-go/blob/0aad511503d4b827e0200482633e1c3974ec8593/elasticsearch.go#L303
+	w.Header().Set("X-Elastic-Product", "Elasticsearch")
+
 	switch {
 	case r.Method == http.MethodGet && r.URL.Path == "/":
 		h.Root(w, r)


### PR DESCRIPTION
Elasticsearch client check a specific header at initialization, see as example [elasticsearch-serverless-go](https://github.com/elastic/elasticsearch-serverless-go/blob/0aad511503d4b827e0200482633e1c3974ec8593/elasticsearch.go#L303-L308). This header is not present in the responses from this mock server, thus official client do not work with it.

This PR adds the header to all responses.
