### PR TITLE
refactor: replace github.com/google/uuid with github.com/gofrs/uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,13 @@ import (
 	"time"
 
 	"github.com/elastic/mock-es/pkg/api"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/rcrowley/go-metrics"
 )
 
 func main() {
 	mux := http.NewServeMux()
-	mux.Handle("/", api.NewAPIHandler(uuid.New(), "", metrics.DefaultRegistry, time.Now().Add(24 *time.Hour) , 0, 0, 0, 0))
+	mux.Handle("/", api.NewAPIHandler(uuid.Must(uuid.New()), "", metrics.DefaultRegistry, time.Now().Add(24 *time.Hour) , 0, 0, 0, 0))
 	if err := http.ListenAndServe("localhost:9200", mux); err != nil {
 		if err != http.ErrServerClosed {
 			panic(err)

--- a/cmd/mock-es/main.go
+++ b/cmd/mock-es/main.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/elastic/mock-es/pkg/api"
-	"github.com/google/uuid"
+	"github.com/gofrs/uuid/v5"
 	"github.com/rcrowley/go-metrics"
 )
 
@@ -39,7 +39,7 @@ func init() {
 	flag.StringVar(&keyFile, "keyfile", "", "path to PEM private key file, empty sting is no TLS")
 	flag.DurationVar(&delay, "delay", 0, "Go 'time.Duration' to wait before processing API request, 0 is no delay")
 
-	uid = uuid.New()
+	uid = uuid.Must(uuid.NewV4())
 	expire = time.Now().Add(24 * time.Hour)
 	flag.Parse()
 	if (percentDuplicate + percentTooMany + percentNonIndex) > 100 {

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,8 @@ module github.com/elastic/mock-es
 
 go 1.21.9
 
-require github.com/google/uuid v1.6.0
-
-require github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
-
-require github.com/mileusna/useragent v1.3.4 // indirect
+require (
+	github.com/gofrs/uuid/v5 v5.2.0
+	github.com/mileusna/useragent v1.3.4
+	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
+)

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
-github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gofrs/uuid/v5 v5.2.0 h1:qw1GMx6/y8vhVsx626ImfKMuS5CvJmhIKKtuyvfajMM=
+github.com/gofrs/uuid/v5 v5.2.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/mileusna/useragent v1.3.4 h1:MiuRRuvGjEie1+yZHO88UBYg8YBC/ddF6T7F56i3PCk=
 github.com/mileusna/useragent v1.3.4/go.mod h1:3d8TOmwL/5I8pJjyVDteHtgDGcefrFUX4ccGOMKNYYc=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/mileusna/useragent"
 	"github.com/rcrowley/go-metrics"
 )
@@ -40,7 +39,7 @@ type BulkResponse struct {
 type APIHandler struct {
 	ActionOdds      [100]int
 	MethodOdds      [100]int
-	UUID            uuid.UUID
+	UUID            fmt.Stringer
 	ClusterUUID     string
 	Expire          time.Time
 	Delay           time.Duration
@@ -48,7 +47,7 @@ type APIHandler struct {
 }
 
 // NewAPIHandler return handler with Action and Method Odds array filled in
-func NewAPIHandler(uuid uuid.UUID, clusterUUID string, metricsRegistry metrics.Registry, expire time.Time, delay time.Duration, percentDuplicate, percentTooMany, percentNonIndex, percentTooLarge uint) *APIHandler {
+func NewAPIHandler(uuid fmt.Stringer, clusterUUID string, metricsRegistry metrics.Registry, expire time.Time, delay time.Duration, percentDuplicate, percentTooMany, percentNonIndex, percentTooLarge uint) *APIHandler {
 	h := &APIHandler{UUID: uuid, Expire: expire, ClusterUUID: clusterUUID, Delay: delay, metricsRegistry: metricsRegistry}
 	if int((percentDuplicate + percentTooMany + percentNonIndex)) > len(h.ActionOdds) {
 		panic(fmt.Errorf("Total of percents can't be greater than %d", len(h.ActionOdds)))


### PR DESCRIPTION
Most elastic projects are using github.com/gofrs/uuid and there has been some effort recently to upgrade to the new major version and avoid using duplicate uuid libraries.
To avoid forcing dependencies on downstream projects and to avoid any breaking change, update the api handler to accept a Stringer.