### PR TITLE
Add deterministic handler

### DIFF
--- a/cmd/mock-es/main.go
+++ b/cmd/mock-es/main.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -14,11 +15,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/elastic/mock-es/pkg/api"
 	"github.com/gofrs/uuid/v5"
 	"go.opentelemetry.io/otel/metric"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/elastic/mock-es/pkg/api"
 )
 
 var (
@@ -115,7 +117,7 @@ func main() {
 			log.Printf("Starting HTTPS server on %s", addr)
 		}
 		if err := http.ListenAndServeTLS(addr, certFile, keyFile, mux); err != nil {
-			if err != http.ErrServerClosed {
+			if !errors.Is(err, http.ErrServerClosed) {
 				log.Fatalf("error running HTTPs server: %s", err)
 			}
 		}
@@ -124,7 +126,7 @@ func main() {
 			log.Printf("Starting HTTP server on %s", addr)
 		}
 		if err := http.ListenAndServe(addr, mux); err != nil {
-			if err != http.ErrServerClosed {
+			if !errors.Is(err, http.ErrServerClosed) {
 				log.Fatalf("error running HTTP server: %s", err)
 			}
 		}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -69,7 +69,7 @@ func NewAPIHandler(
 	historyCap uint,
 ) *APIHandler {
 
-	h, err := newAPIHAndler(uuid, clusterUUID, meterProvider, expire, delay, historyCap)
+	h, err := newAPIHandler(uuid, clusterUUID, meterProvider, expire, delay, historyCap)
 	if err != nil {
 		panic(fmt.Errorf("failed to create APIHandler: %w", err))
 	}
@@ -82,7 +82,7 @@ func NewAPIHandler(
 	return h
 }
 
-// NewDeterministicAPIHandler returns a handler wich which use handler to process
+// NewDeterministicAPIHandler returns a handler which uses handler to process
 // each action in the bulk request.
 func NewDeterministicAPIHandler(
 	uuid fmt.Stringer,
@@ -94,7 +94,7 @@ func NewDeterministicAPIHandler(
 	handler func(action Action, event []byte) int,
 ) *APIHandler {
 
-	h, err := newAPIHAndler(uuid, clusterUUID, meterProvider, expire, delay, historyCap)
+	h, err := newAPIHandler(uuid, clusterUUID, meterProvider, expire, delay, historyCap)
 	if err != nil {
 		panic(fmt.Errorf("failed to create APIHandler: %w", err))
 	}
@@ -104,7 +104,7 @@ func NewDeterministicAPIHandler(
 	return h
 }
 
-func newAPIHAndler(
+func newAPIHandler(
 	uuid fmt.Stringer,
 	clusterUUID string,
 	meterProvider metric.MeterProvider,

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -25,6 +25,19 @@ type BulkResponse struct {
 	Items  []map[string]any `json:"items,omitempty"`
 }
 
+// Action is the action for /_bulk requests.
+type Action struct {
+	Action string
+	Meta   json.RawMessage
+}
+
+// RequestRecord is a record of a request
+type RequestRecord struct {
+	Method string `json:"method"`
+	URI    string `json:"uri"`
+	Body   string `json:"body"`
+}
+
 // APIHandler struct.  Use NewAPIHandler to make sure it is filled in correctly for use.
 type APIHandler struct {
 	ActionOdds   [100]int
@@ -40,19 +53,6 @@ type APIHandler struct {
 	configMu     sync.RWMutex
 
 	deterministicHandler func(action Action, event []byte) int
-}
-
-// Action is the action for /_bulk requests.
-type Action struct {
-	Action string
-	Meta   json.RawMessage
-}
-
-// RequestRecord is a record of a request
-type RequestRecord struct {
-	Method string `json:"method"`
-	URI    string `json:"uri"`
-	Body   string `json:"body"`
 }
 
 // NewAPIHandler return handler with Action and Method Odds array filled in

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -243,7 +243,10 @@ func (h *APIHandler) Bulk(w http.ResponseWriter, r *http.Request) {
 
 		action, err := h.parseAction(b)
 		if err != nil {
-			log.Printf("failed to parse action response: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = w.Write([]byte(
+				fmt.Sprintf(`{"error": "failed to parse action: %v"}`, err)))
+			log.Printf("failed to parse action: %v", err)
 			return
 		}
 
@@ -274,6 +277,9 @@ func (h *APIHandler) Bulk(w http.ResponseWriter, r *http.Request) {
 	h.recordRequest(r, body)
 	brBytes, err := json.Marshal(br)
 	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(
+			fmt.Sprintf(`{"error": "error marshal bulk reply: %v"}`, err)))
 		log.Printf("error marshal bulk reply: %s", err)
 		return
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -262,11 +262,13 @@ func (h *APIHandler) Bulk(w http.ResponseWriter, r *http.Request) {
 
 		var actionStatus int
 		var item map[string]any
-		if h.deterministicHandler == nil && action.Action == "create" {
-			actionStatus = h.ActionOdds[rand.Intn(len(h.ActionOdds))]
-			item = map[string]any{action.Action: map[string]any{"status": actionStatus}}
-		} else {
+		if h.deterministicHandler != nil {
 			actionStatus = h.deterministicHandler(action, b)
+			item = map[string]any{action.Action: map[string]any{"status": actionStatus}}
+		} else if action.Action == "create" {
+			// this is the probabilistic handler, it does nothing for all the
+			// other actions, only create is handled according to the odds.
+			actionStatus = h.ActionOdds[rand.Intn(len(h.ActionOdds))]
 			item = map[string]any{action.Action: map[string]any{"status": actionStatus}}
 		}
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -82,7 +82,7 @@ func NewAPIHandler(
 	return h
 }
 
-// NewDeterministicAPIHandler returns a handler wich will use handler to process
+// NewDeterministicAPIHandler returns a handler wich which use handler to process
 // each action in the bulk request.
 func NewDeterministicAPIHandler(
 	uuid fmt.Stringer,


### PR DESCRIPTION
Add a deterministic handler to the API server. This allow users of the library to pass in a function to process each action in the bulk request and return the status of each action.
This allow deterministic unit test, giving full control of the server's response to the user.