### PR TITLE
Add a server error status flag

### DIFF
--- a/pkg/api/metrics.go
+++ b/pkg/api/metrics.go
@@ -7,17 +7,18 @@ import (
 )
 
 type metrics struct {
-	rootTotalMetrics           metric.Int64Counter
-	licenseTotalMetrics        metric.Int64Counter
-	bulkCreateTotalMetrics     metric.Int64Counter
-	bulkCreateDuplicateMetrics metric.Int64Counter
-	bulkCreateTooManyMetrics   metric.Int64Counter
-	bulkCreateNonIndexMetrics  metric.Int64Counter
-	bulkCreateOkMetrics        metric.Int64Counter
-	bulkCreateTooLargeMetrics  metric.Int64Counter
-	bulkIndexTotalMetrics      metric.Int64Counter
-	bulkUpdateTotalMetrics     metric.Int64Counter
-	bulkDeleteTotalMetrics     metric.Int64Counter
+	rootTotalMetrics             metric.Int64Counter
+	licenseTotalMetrics          metric.Int64Counter
+	bulkCreateTotalMetrics       metric.Int64Counter
+	bulkCreateDuplicateMetrics   metric.Int64Counter
+	bulkCreateTooManyMetrics     metric.Int64Counter
+	bulkCreateNonIndexMetrics    metric.Int64Counter
+	bulkCreateOkMetrics          metric.Int64Counter
+	bulkCreateTooLargeMetrics    metric.Int64Counter
+	bulkCreateServerErrorMetrics metric.Int64Counter
+	bulkIndexTotalMetrics        metric.Int64Counter
+	bulkUpdateTotalMetrics       metric.Int64Counter
+	bulkDeleteTotalMetrics       metric.Int64Counter
 }
 
 func newMetrics(provider metric.MeterProvider) (*metrics, error) {
@@ -25,17 +26,18 @@ func newMetrics(provider metric.MeterProvider) (*metrics, error) {
 	meter := provider.Meter("github.com/elastic/mock-es")
 
 	for k, v := range map[string]*metric.Int64Counter{
-		"root.total":            &m.rootTotalMetrics,
-		"license.total":         &m.licenseTotalMetrics,
-		"bulk.create.total":     &m.bulkCreateTotalMetrics,
-		"bulk.create.duplicate": &m.bulkCreateDuplicateMetrics,
-		"bulk.create.too_many":  &m.bulkCreateTooManyMetrics,
-		"bulk.create.non_index": &m.bulkCreateNonIndexMetrics,
-		"bulk.create.ok":        &m.bulkCreateOkMetrics,
-		"bulk.create.too_large": &m.bulkCreateTooLargeMetrics,
-		"bulk.index.total":      &m.bulkIndexTotalMetrics,
-		"bulk.update.total":     &m.bulkUpdateTotalMetrics,
-		"bulk.delete.total":     &m.bulkDeleteTotalMetrics,
+		"root.total":               &m.rootTotalMetrics,
+		"license.total":            &m.licenseTotalMetrics,
+		"bulk.create.total":        &m.bulkCreateTotalMetrics,
+		"bulk.create.duplicate":    &m.bulkCreateDuplicateMetrics,
+		"bulk.create.too_many":     &m.bulkCreateTooManyMetrics,
+		"bulk.create.non_index":    &m.bulkCreateNonIndexMetrics,
+		"bulk.create.ok":           &m.bulkCreateOkMetrics,
+		"bulk.create.too_large":    &m.bulkCreateTooLargeMetrics,
+		"bulk.create.server_error": &m.bulkCreateServerErrorMetrics,
+		"bulk.index.total":         &m.bulkIndexTotalMetrics,
+		"bulk.update.total":        &m.bulkUpdateTotalMetrics,
+		"bulk.delete.total":        &m.bulkDeleteTotalMetrics,
 	} {
 		if err := newCounter(meter, v, k); err != nil {
 			return nil, err


### PR DESCRIPTION
Add a `-bulkerr` flag that gives a chance of returning an http status 500 (internal server error) for a bulk request. (This is useful for testing currently since Beats retries on 500s but the OTel Elasticsearch exporter does not.)

I also grouped most of the flags into a config struct, to have fewer functions that take a long sequence of easily-transposed integer parameters.