### PR TITLE
Add a default cluster UUID

### DIFF
--- a/cmd/mock-es/main.go
+++ b/cmd/mock-es/main.go
@@ -47,7 +47,7 @@ func init() {
 	flag.UintVar(&percentNonIndex, "nonindex", 0, "percent chance StatusNotAcceptable is returned for create action")
 	flag.UintVar(&percentTooLarge, "toolarge", 0, "percent chance StatusEntityTooLarge is returned for POST method on _bulk endpoint")
 	flag.UintVar(&historyCap, "history", 0, "number of request bodies to keep, available on _history endpoint")
-	flag.StringVar(&clusterUUID, "clusteruuid", "580445a9-f89f-429f-a84f-14956e5ad968", "Cluster UUID of Elasticsearch we are mocking")
+	flag.StringVar(&clusterUUID, "clusteruuid", api.DefaultClusterUUID, "Cluster UUID of Elasticsearch we are mocking")
 	flag.DurationVar(&metricsInterval, "metrics", 0, "Go 'time.Duration' to wait between printing metrics to stdout, 0 is no metrics")
 	flag.StringVar(&certFile, "certfile", "", "path to PEM certificate file, empty sting is no TLS")
 	flag.StringVar(&keyFile, "keyfile", "", "path to PEM private key file, empty sting is no TLS")

--- a/cmd/mock-es/main.go
+++ b/cmd/mock-es/main.go
@@ -47,7 +47,7 @@ func init() {
 	flag.UintVar(&percentNonIndex, "nonindex", 0, "percent chance StatusNotAcceptable is returned for create action")
 	flag.UintVar(&percentTooLarge, "toolarge", 0, "percent chance StatusEntityTooLarge is returned for POST method on _bulk endpoint")
 	flag.UintVar(&historyCap, "history", 0, "number of request bodies to keep, available on _history endpoint")
-	flag.StringVar(&clusterUUID, "clusteruuid", "", "Cluster UUID of Elasticsearch we are mocking")
+	flag.StringVar(&clusterUUID, "clusteruuid", "580445a9-f89f-429f-a84f-14956e5ad968", "Cluster UUID of Elasticsearch we are mocking")
 	flag.DurationVar(&metricsInterval, "metrics", 0, "Go 'time.Duration' to wait between printing metrics to stdout, 0 is no metrics")
 	flag.StringVar(&certFile, "certfile", "", "path to PEM certificate file, empty sting is no TLS")
 	flag.StringVar(&keyFile, "keyfile", "", "path to PEM private key file, empty sting is no TLS")

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -69,6 +69,11 @@ func NewAPIHandler(
 	historyCap uint,
 ) *APIHandler {
 
+	// Always set a cluster UUID, so things like Beats monitoring always work
+	if clusterUUID == "" {
+		clusterUUID = "580445a9-f89f-429f-a84f-14956e5ad968"
+	}
+
 	h, err := newAPIHandler(uuid, clusterUUID, meterProvider, expire, delay, historyCap)
 	if err != nil {
 		panic(fmt.Errorf("failed to create APIHandler: %w", err))

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -18,6 +18,8 @@ import (
 	"go.opentelemetry.io/otel/metric"
 )
 
+var DefaultClusterUUID = "580445a9-f89f-429f-a84f-14956e5ad968"
+
 // BulkResponse is an Elastic Search Bulk Response, assuming
 // filter_path is "errors,items.*.error,items.*.status"
 type BulkResponse struct {
@@ -71,7 +73,7 @@ func NewAPIHandler(
 
 	// Always set a cluster UUID, so things like Beats monitoring always work
 	if clusterUUID == "" {
-		clusterUUID = "580445a9-f89f-429f-a84f-14956e5ad968"
+		clusterUUID = DefaultClusterUUID
 	}
 
 	h, err := newAPIHandler(uuid, clusterUUID, meterProvider, expire, delay, historyCap)


### PR DESCRIPTION
If the cluster UUID is not set it can cause problems in some cases, one of those is the beat module from Metricbeat that refuses to collect the stats endpoint if Elasticsearch does not have a cluster UUID set.